### PR TITLE
Updated pokemon id handeling - now works with pokemon forms! 

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,18 +90,18 @@
         </div>
       </div>
     </header>
-    <main class="text-white flex flex-col items-center">
+    <main class="text-white flex flex-col items-center gap-5">
       <section
-        class="flex flex-col gap-5 items-center w-11/12 max-w-sm rounded-sm relative"
+        class="flex flex-col gap-5 items-center w-11/12 max-w-sm relative"
       >
         <div
-          class="bg-dark-hl w-full py-5 rounded flex justify-center items-center"
+          class="bg-dark-hl w-full py-5 rounded-sm flex justify-center items-center"
         >
           <h2 id="pokeName" class="text-xl font-semibold"></h2>
         </div>
         <div
           id="display"
-          class="bg-white flex items-center justify-center rounded-md w-full h-36"
+          class="bg-white flex items-center justify-center rounded-sm w-full h-36"
         >
           <img id="pokemonImage" class="size-36" />
         </div>
@@ -111,29 +111,32 @@
         ></div>
         <div
           id="choices"
-          class="flex items-center justify-center gap-5 bg-white py-5 w-full rounded-md"
+          class="flex items-center justify-center gap-5 bg-white py-5 w-full rounded-sm"
         ></div>
         <div
           id="type-message"
-          class="hidden w-full font-bold text-lg text-center bg-dark-hl rounded-md py-2"
+          class="hidden w-full font-bold text-lg text-center bg-dark-hl rounded-sm py-2"
         ></div>
         <div
           id="typings"
-          class="flex flex-wrap justify-center gap-2 w-full bg-dark-hl rounded-md p-3 sm:p-5"
+          class="flex flex-wrap justify-center gap-2 w-full bg-dark-hl rounded-sm p-3 sm:p-5"
         ></div>
         <div
-          id="stats"
-          class="hidden bg-dark-hl top-0 -right-44 rounded-md p-5"
+          class="md:absolute md:flex-col top-0 -left-48 flex flex-row justify-center items-center md:items-start w-full md:w-auto max-w-sm rounded-sm bg-dark-hl py-5 md:p-10 gap-10"
         >
-          <h3 class="text-white text-lg font-semibold">Stats</h3>
-          <div>
-            <p>
-              <span id="stats-correct">0</span> /
-              <span id="stats-total">0</span>
-            </p>
-          </div>
-          <div>
-            <p><span id="stats-percentage">0</span> %</p>
+          <h2 class="font-semibold text-xl">Practice</h2>
+          <div class="flex flex-row md:flex-col gap-5">
+            <div class="flex flex-col items-start">
+              <span class="text-lg">Stats</span>
+              <p class="font-light">
+                <span id="stats-correct"></span> /
+                <span id="stats-total"></span>
+              </p>
+            </div>
+            <div class="flex flex-col items-start">
+              <span class="text-lg">Percentage</span>
+              <p class="font-light"><span id="stats-percentage"></span> %</p>
+            </div>
           </div>
         </div>
       </section>

--- a/src/js/api/fetchPokemonAmount.mjs
+++ b/src/js/api/fetchPokemonAmount.mjs
@@ -1,19 +1,29 @@
 export default async function fetchPokemonAmount() {
+  // All existing pokemon without forms, this is not changing automatically at this moment
+  const amountPokemon = 1025;
 
-    const amountFailSafe = 1302;
+  try {
+    const response = await fetch('https://pokeapi.co/api/v2/pokemon');
+    const data = await response.json();
+    const allPokemon = data.count;
+    // Fetches number of resoures from the api
 
-    try {
-        
-        const response = await fetch('https://pokeapi.co/api/v2/pokemon');
-        const data = await response.json();
-        const count = data.count;
+    // All the forms have an id starting from 10001
+    const extraForms = allPokemon - amountPokemon;
+    const pokeForms = [];
+    for (let i = 1; i < extraForms + 1; i++) {
+      pokeForms.push(10000 + i);
+    }
 
-        localStorage.setItem('currentPokemonAmount', count);
-        console.log('Pokemon amount:', count);
-    
-    } catch (error) {
-        console.error(error);
-        localStorage.setItem('currentPokemonAmount', amountFailSafe);
+    const pokemonData = {
+      allPokemon: allPokemon,
+      pokemon: amountPokemon,
+      extraForms: pokeForms,
     };
 
-};
+    localStorage.setItem('pokemonData', JSON.stringify(pokemonData));
+  } catch (error) {
+    console.error(error);
+    localStorage.setItem('pokemonData', amountPokemon);
+  }
+}

--- a/src/js/api/fetchRandomPokemon.mjs
+++ b/src/js/api/fetchRandomPokemon.mjs
@@ -1,7 +1,17 @@
 export default function fetchRandomPokemon() {
+  const pokemonData = JSON.parse(localStorage.getItem('pokemonData'));
 
-    const amount = localStorage.getItem('currentPokemonAmount');
-    const randomPokemon = Math.floor(Math.random() * amount) + 1;
+  const allPokemon = pokemonData.allPokemon;
+  const pokemons = pokemonData.pokemon;
+  const extraForms = pokemonData.extraForms;
+
+  const randomPokemon = Math.floor(Math.random() * allPokemon) + 1;
+
+  if (randomPokemon > pokemons) {
+    const formIndex = randomPokemon - pokemons;
+    const form = extraForms[formIndex - 1];
+    return form;
+  } else {
     return randomPokemon;
-
-};
+  }
+}

--- a/src/js/render/renderPokemon.mjs
+++ b/src/js/render/renderPokemon.mjs
@@ -2,7 +2,9 @@ export default function renderPokemon(pokemon) {
   const imageContainer = document.getElementById('pokemonImage');
   const nameContainer = document.getElementById('pokeName');
 
-  const pokeName = pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1);
+  const pokeNameUppercase =
+    pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1);
+  const pokeName = pokeNameUppercase.replace(/-/g, ' ');
   nameContainer.textContent = pokeName;
 
   imageContainer.src = pokemon.image;

--- a/src/js/render/renderResetButton.mjs
+++ b/src/js/render/renderResetButton.mjs
@@ -13,7 +13,7 @@ export function renderResetButton() {
     'justify-center',
     'size-20',
     'bg-dark-hl',
-    'rounded-md',
+    'rounded-sm',
     'px-5',
   );
 
@@ -39,7 +39,7 @@ export function renderSubmitButton() {
     'flex',
     'items-center',
     'justify-center',
-    'rounded-md',
+    'rounded-sm',
     'h-20',
     'font-semibold',
     'text-2xl',

--- a/src/js/stats/startStats.mjs
+++ b/src/js/stats/startStats.mjs
@@ -3,7 +3,7 @@ import updateStatsDisplay from './updateStatsDisplay.mjs';
 export default function startStats() {
   const fetchHistory = JSON.parse(localStorage.getItem('stats'));
 
-  if (!fetchHistory) {
+  if (fetchHistory) {
     sessionStorage.setItem('stats', JSON.stringify(fetchHistory));
     updateStatsDisplay();
   } else {


### PR DESCRIPTION
Updated the randomized pokemon id!

The api returns a count of pokemon that is bigger than the original length (1025 in 2024), but returns the whole list included pokemon form. The current count is 1302. 

The problem is that the forms does not keep up with the count as its id, differently from the regular pokemons id 1 - 1025.

Created a function to convert all values over 1025 to its responding id ->

1026 = form 1 (index 0)
Takes number from index 0 in array of forms. 
Returns id that is formatted as 10001 ...